### PR TITLE
add 'imgtool' as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "asyncclick",
     "colorama",
     "httpx",
+    "imgtool",
     "pyyaml",
     "rich",
     "trio",


### PR DESCRIPTION
'imgtool' is needed in order to install CLI with:

``` sh
$ pipx install -e .
```

and use it without any system packages.