### PR TITLE
Add pytest plugin

### DIFF
--- a/golioth/pytest_plugin.py
+++ b/golioth/pytest_plugin.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+from golioth import Client
+
+def pytest_addoption(parser):
+    parser.addoption("--api-key", type=str,
+                     help="Golioth API key")
+    parser.addoption("--device-name", type=str,
+                     help="Golioth device name")
+
+
+@pytest.fixture(scope='session')
+def anyio_backend():
+    return 'trio'
+
+@pytest.fixture(scope="session")
+def api_key(request):
+    if request.config.getoption("--api-key") is not None:
+        return request.config.getoption("--api-key")
+    else:
+        return os.environ['GOLIOTH_API_KEY']
+
+@pytest.fixture(scope="session")
+def device_name(request):
+    if request.config.getoption("--device-name") is not None:
+        return request.config.getoption("--device-name")
+    else:
+        return os.environ['GOLIOTH_DEVICE_NAME']
+
+@pytest.fixture(scope="module")
+async def project(api_key):
+    client = Client(api_url = "https://api.golioth.dev",
+                    api_key = api_key)
+    project = (await client.get_projects())[0]
+
+    return project
+
+@pytest.fixture(scope="module")
+async def device(project, device_name):
+    device = await project.device_by_name(device_name)
+
+    return device

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "golioth"
 version = "0.2.0"
 authors = [
-    { name="Marcin Niestroj", email="m.niestroj@emb.dev" }
+    { name="Marcin Niestroj", email="m.niestroj@emb.dev" },
+    { name="Sam Friedman", email="sam@golioth.io" }
 ]
 description = "Golioth client Python library"
 license = "Apache-2.0"
@@ -33,8 +34,8 @@ dependencies = [
 golioth = "golioth.cli:main"
 
 [project.utils]
-"Homepage" = "https://github.com/golioth/golioth-zephyr-sdk"
-"Bug Tracker" = "https://github.com/golioth/golioth-zephyr-sdk/issues"
+"Homepage" = "https://github.com/golioth/python-golioth-tools"
+"Bug Tracker" = "https://github.com/golioth/python-golioth-tools/issues"
 
 [project.entry-points.pytest11]
 golioth = "golioth.pytest_plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golioth"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     { name="Marcin Niestroj", email="m.niestroj@emb.dev" },
     { name="Sam Friedman", email="sam@golioth.io" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
+    "Framework :: Pytest",
 ]
 dependencies = [
     "anyio",
@@ -34,3 +35,6 @@ golioth = "golioth.cli:main"
 [project.utils]
 "Homepage" = "https://github.com/golioth/golioth-zephyr-sdk"
 "Bug Tracker" = "https://github.com/golioth/golioth-zephyr-sdk/issues"
+
+[project.entry-points.pytest11]
+golioth = "golioth.pytest_plugin"


### PR DESCRIPTION
Adds a pytest plugin that can be used to provide pytest test cases with a device and/or project object. This makes it easier to integrate this library into pytest with less boilerplate code.