### PR TITLE
Add create device

### DIFF
--- a/golioth/cli.py
+++ b/golioth/cli.py
@@ -592,6 +592,20 @@ async def list(config):
 
         console.print([d.info for d in devices])
 
+@device.command()
+@click.argument('name')
+@click.argument('hardware_id')
+@pass_config
+async def create(config, name, hardware_id):
+    """Create a device"""
+    with console.status('Creating device...'):
+        client = Client(api_url = config.api_url, api_key = config.api_key, access_token = config.access_token)
+        project = await Project.get_by_id(client, config.default_project)
+
+        device = await project.create_device(name, hardware_id)
+
+        console.print(device.info)
+
 
 @cli.group()
 def credentials():

--- a/golioth/cli.py
+++ b/golioth/cli.py
@@ -606,6 +606,16 @@ async def create(config, name, hardware_id):
 
         console.print(device.info)
 
+@device.command()
+@click.argument('name')
+@pass_config
+async def delete(config, name):
+    """Delete a device"""
+    with console.status('Deleting device...'):
+        client = Client(api_url = config.api_url, api_key = config.api_key, access_token = config.access_token)
+        project = await Project.get_by_id(client, config.default_project)
+
+        await project.delete_device(name)
 
 @cli.group()
 def credentials():

--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -226,6 +226,15 @@ class Project(ApiNodeMixin):
 
         return devices[0]
 
+    async def create_device(self, name: str, hardware_id: str) -> Device:
+        body = {
+            "name" : name,
+            "hardwareIds" : [hardware_id],
+            "tagIds" : []
+        }
+        resp = await self.post('devices', json=body)
+        return Device(self, resp.json()['data'])
+
     async def get_logs(self, params: dict = {}) -> list[LogEntry]:
         resp = await self.get('logs', params=params)
         return [LogEntry(e) for e in reversed(resp.json()['list'])]

--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -235,6 +235,10 @@ class Project(ApiNodeMixin):
         resp = await self.post('devices', json=body)
         return Device(self, resp.json()['data'])
 
+    async def delete_device(self, name: str):
+        device_id = (await self.device_by_name(name)).id
+        await self.delete(f'devices/{device_id}')
+
     async def get_logs(self, params: dict = {}) -> list[LogEntry]:
         resp = await self.get('logs', params=params)
         return [LogEntry(e) for e in reversed(resp.json()['list'])]


### PR DESCRIPTION
Add the ability to programmatically create (and delete) devices through the REST API. This will allow our CI tests to create devices in the console to use for tests, so we won't have to manually create them anymore.