### PR TITLE
add ability to delete device by id

### DIFF
--- a/golioth/cli.py
+++ b/golioth/cli.py
@@ -615,7 +615,7 @@ async def delete(config, name):
         client = Client(api_url = config.api_url, api_key = config.api_key, access_token = config.access_token)
         project = await Project.get_by_id(client, config.default_project)
 
-        await project.delete_device(name)
+        await project.delete_device_by_name(name)
 
 @device.command()
 @click.argument('device_name')

--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -237,9 +237,15 @@ class Project(ApiNodeMixin):
         resp = await self.post('devices', json=body)
         return Device(self, resp.json()['data'])
 
-    async def delete_device(self, name: str):
-        device_id = (await self.device_by_name(name)).id
-        await self.delete(f'devices/{device_id}')
+    async def delete_device_by_id(self, id: str):
+        await self.delete(f'devices/{id}')
+
+    async def delete_device(self, dev: Device):
+        await self.delete_device_by_id(dev.id)
+
+    async def delete_device_by_name(self, name: str):
+        dev = await self.device_by_name(name)
+        await self.delete_device(dev)
 
     async def get_logs(self, params: dict = {}) -> list[LogEntry]:
         resp = await self.get('logs', params=params)

--- a/golioth/pytest_plugin.py
+++ b/golioth/pytest_plugin.py
@@ -50,4 +50,4 @@ async def device(project, device_name):
 
         yield device
 
-        await project.delete_device(name)
+        await project.delete_device(device)


### PR DESCRIPTION
If the device ID is known then we can delete the device directly, instead of looking up the device ID using the name. This saves us one API call.