### PR TITLE
cli: fix behavior when api-key is specified

### DIFF
--- a/golioth/cli.py
+++ b/golioth/cli.py
@@ -31,22 +31,32 @@ class Config:
 pass_config = click.make_pass_decorator(Config, ensure=True)
 
 @click.group()
-@click.option('-c', '--config-path', type=Path,
-              help='Path to goliothctl configuration',
-              default=Path.home() / '.golioth' / '.goliothctl.yaml')
-@click.option('--api-key', help='Api key')
+@click.option('-c', '--config-path', type=Path, show_default=True,
+              default=Path.home() / '.golioth' / '.goliothctl.yaml',
+              help='Path to goliothctl configuration.')
+@click.option('--api-key', default=None, show_default=True,
+              help='API key to use instead of stored config')
+@click.option('--api-url', default="https://api.golioth.io", show_default=True,
+              help='URL of Golioth REST API. Only applicable when --api-key is specified')
 @pass_config
-def cli(config, config_path, api_key):
-    config.api_key = api_key
+def cli(config, config_path, api_key, api_url):
 
-    with config_path.open('r') as fp:
-        config_dict = yaml.load(fp, yaml.SafeLoader)
-        if 'accesstoken' in config_dict:
-            config.access_token = config_dict['accesstoken']
-        if 'projectid' in config_dict:
-            config.default_project = config_dict['projectid']
-        if 'apiurl' in config_dict:
-            config.api_url = config_dict['apiurl']
+    if api_key == None:
+        # Load stored config
+        with config_path.open('r') as fp:
+            config_dict = yaml.load(fp, yaml.SafeLoader)
+            if 'accesstoken' in config_dict:
+                config.access_token = config_dict['accesstoken']
+            if 'projectid' in config_dict:
+                config.default_project = config_dict['projectid']
+            if 'apiurl' in config_dict:
+                config.api_url = config_dict['apiurl']
+
+    else:
+        # Use supplied API key
+        config.api_key = api_key
+        config.default_project = None
+        config.api_url = api_url
 
 def rpc_params(params: str) -> Union[list, dict]:
     parsed = json.loads(params)

--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -205,9 +205,13 @@ class Project(ApiNodeMixin):
         return self.client.headers
 
     @staticmethod
-    async def get_by_id(client: Client, project_id: str):
-        resp = await client.get(f'projects/{project_id}')
-        return Project(client, resp.json()['data'])
+    async def get_by_id(client: Client, project_id: str | None) -> Project:
+        if project_id == None:
+            project = (await client.get_projects())[0]
+        else:
+            resp = await client.get(f'projects/{project_id}')
+            project = Project(client, resp.json()['data'])
+        return project
 
     @property
     def id(self) -> str:


### PR DESCRIPTION
* Add flag for supplying a Project name
* Require a Project name when an API key is included as an arg
* Add optional API URL flag

By default, the stored configuration is loaded from ~/.golioth/.goliothctl.yaml. When an API key is supplied as a command line argument, the default project name from the stored config is used. If the key and the project name don't match, all operations fail.

This commit changes the behavior as follows:

1. If no API key is included as a CLI argument, the stored config is used
2. When an API key is supplied, a Project name must also be supplied so the two can be used in tandem.
3. An optional API url may be supplied but it will only be used when an API key has also been supplied.