### PR TITLE
Fix rollout_set()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [v0.5.1] - 2024-01-20
+
+### Fixed
+
+- Fix Release.rollout_set() function so tags are not overwritten
+
+## [v0.5.0] - 2024-01-11
 
 ### Breaking Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golioth"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     { name="Marcin Niestroj", email="m.niestroj@emb.dev" },
     { name="Sam Friedman", email="sam@golioth.io" }


### PR DESCRIPTION
* Fix the the Release.rollout_set() function so it doesn't overwrite tags
* Mark a patch release to v0.5.1