### PR TITLE
settings: fix incorrect data type for booleans

### DIFF
--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -631,12 +631,12 @@ class DeviceSettings(ApiNodeMixin):
 
     async def set(self, key: str, value: Union[int, float, bool, str],
                   override: bool = True):
-        if isinstance(value, int):
+        if isinstance(value, bool):
+            data_type = 'boolean'
+        elif isinstance(value, int):
             data_type = 'integer'
         elif isinstance(value, float):
             data_type = 'float'
-        elif isinstance(value, bool):
-            data_type = 'boolean'
         elif isinstance(value, str):
             data_type = 'string'
         else:
@@ -942,12 +942,12 @@ class ProjectSettings:
 
     async def set(self, key: str, value: Union[int, float, bool, str],
                   override: bool = True):
-        if isinstance(value, int):
+        if isinstance(value, bool):
+            data_type = 'boolean'
+        elif isinstance(value, int):
             data_type = 'integer'
         elif isinstance(value, float):
             data_type = 'float'
-        elif isinstance(value, bool):
-            data_type = 'boolean'
         elif isinstance(value, str):
             data_type = 'string'
         else:


### PR DESCRIPTION
Python booleans are a subclass of integers, which means that `isinstance(False, int) == True`. When creating (or updating) a setting, we first check if a value is an integer then check if it is a boolean. Because booleans are integers, we always treat booleans as ints. Checking if a value is a boolean first will allow us to distinguish between the types correctly.

Fixes golioth/firmware-issue-tracker#452