### PR TITLE
rpc: allow sending rpc with no arguments

### DIFF
--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -609,8 +609,10 @@ class DeviceRPC(ApiNodeMixin):
         async def call_method(*args, **kwargs):
             if args:
                 params = args
-            else:
+            elif kwargs:
                 params = kwargs
+            else:
+                params = []
 
             return await self.call(name, params)
 


### PR DESCRIPTION
Fixes golioth/firmware-issue-tracker#468