### PR TITLE
pytest_plugin: add option for masking sensitive data in GH actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golioth"
-version = "0.6.2"
+version = "0.6.3"
 authors = [
     { name="Marcin Niestroj", email="m.niestroj@emb.dev" },
     { name="Sam Friedman", email="sam@golioth.io" }


### PR DESCRIPTION
Sensitive data can be masked in GitHub logs by outputting a special string in the format `::add-mask::<secret>`.

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log