### PR TITLE
Fix device stream get

### DIFF
--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -596,13 +596,10 @@ class DeviceStream(ApiNodeMixin):
             response = await c.post(f'stream', json=json_data)
             return response.json()
 
-    async def set(self, path: str, value: ValueType) -> None:
-        async with self.http_client as c:
-            await c.post(f'stream/{path}', json=value)
-
-    async def delete(self, path: str) -> None:
-        async with self.http_client as c:
-            await c.delete(f'stream/{path}')
+    # TODO: This API is no longer valid
+    # async def set(self, path: str, value: ValueType) -> None:
+        # async with self.http_client as c:
+            # await c.post(f'stream/{path}', json=value)
 
     @asynccontextmanager
     async def websocket(self, params: dict = {}) -> WebSocketConnection:


### PR DESCRIPTION
Fix the device stream get URL and add optional parameters

This does not handle errors from the server or otherwise process the response. It merely returns the server response in JSON format.

resolves https://github.com/golioth/golioth-firmware-sdk/issues/583