### PR TITLE
Szczys/split device stream get fix

### DIFF
--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -556,14 +556,42 @@ class DeviceStream(ApiNodeMixin):
     def headers(self) -> Dict[str, str]:
         return self.device.headers
 
-    async def get(self, path: str) -> DeviceStream.ValueType:
-        query = ('{"fields":[{"path":"device_id","type":""},' +
-                    '{"path":"time","type":""},{"path":"*","type":""}],' +
-                    '"filters":[{"path":' + f'"{path}"' +
-                    ',"op":"<>","value":""}]}')
+    async def get(self,
+                  path: str | None = None,
+                  start: str | None = None,
+                  end: str | None = None,
+                  interval: str | None = None,
+                  encoded_query: str | None = None,
+                  query_time_bucket: str | None = None,
+                  page: int = 0,
+                  per_page: int = 10) -> DeviceStream.ValueType:
+        if encoded_query is not None:
+            query = encoded_query
+        elif path is not None:
+            query = ('{"fields":[{"path":"device_id","type":""},' +
+                     '{"path":"time","type":""},{"path":"*","type":""}],' +
+                     '"filters":[{"path":' + f'"{path}"' +
+                     ',"op":"<>","value":""}]}')
+        else:
+            query = ('{"fields":[{"path":"device_id","type":""},' +
+                     '{"path":"time","type":""},{"path":"*","type":""}],' +
+                     '"filters":[]}')
+
         json_data = {
                 "encodedQuery":query,
+                "page":page,
+                "perPage":per_page,
                 }
+
+        if start is not None:
+            json_data["start"] = start
+        if end is not None:
+            json_data["end"] = end
+        if interval is not None:
+            json_data["interval"] = interval
+        if query_time_bucket is not None:
+            json_data["query.timeBucket"] = query_time_bucket
+
         async with self.http_client as c:
             response = await c.post('stream', json=json_data)
             return response.json()

--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -557,9 +557,16 @@ class DeviceStream(ApiNodeMixin):
         return self.device.headers
 
     async def get(self, path: str) -> DeviceStream.ValueType:
+        query = ('{"fields":[{"path":"device_id","type":""},' +
+                    '{"path":"time","type":""},{"path":"*","type":""}],' +
+                    '"filters":[{"path":' + f'"{path}"' +
+                    ',"op":"<>","value":""}]}')
+        json_data = {
+                "encodedQuery":query,
+                }
         async with self.http_client as c:
-            response = await c.get(f'stream/{path}')
-            return response.json()['data']
+            response = await c.post('stream', json=json_data)
+            return response.json()
 
     async def set(self, path: str, value: ValueType) -> None:
         async with self.http_client as c:

--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -596,13 +596,10 @@ class DeviceStream(ApiNodeMixin):
             response = await c.post('stream', json=json_data)
             return response.json()
 
-    async def set(self, path: str, value: ValueType) -> None:
-        async with self.http_client as c:
-            await c.post(f'stream/{path}', json=value)
-
-    async def delete(self, path: str) -> None:
-        async with self.http_client as c:
-            await c.delete(f'stream/{path}')
+    # TODO: This API is no longer valid
+    # async def set(self, path: str, value: ValueType) -> None:
+        # async with self.http_client as c:
+            # await c.post(f'stream/{path}', json=value)
 
     @asynccontextmanager
     async def websocket(self, params: dict = {}) -> WebSocketConnection:


### PR DESCRIPTION
This reimplements the changes in #36 but with [the commit split as requested](https://github.com/golioth/python-golioth-tools/pull/36#pullrequestreview-2293283928) by @mniestroj. I have opened #37 to revert the merge I made mistakenly before splitting.

Fix the device stream get URL and add optional parameters

This does not handle errors from the server or otherwise process the response. It merely returns the server response in JSON format.