### PR TITLE
release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.6.3] - 2024-09-11
+## [v0.6.4] - 2024-09-11
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is not yet published in PyPI. It can be installed directly from Git
 the following command:
 
 ``` sh
-pip install git+https://github.com/golioth/python-golioth-tools@v0.6.3
+pip install git+https://github.com/golioth/python-golioth-tools@v0.6.4
 ```
 
 Alternatively you can clone this repo and then run the following at the repo root:


### PR DESCRIPTION
This updates the release number from v0.6.3 to v0.6.4. A tag already existed for the earlier version number but no release was made.

see CHANGELOG for details.