### PR TITLE
unpin trio version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "imgtool",
     "pyyaml",
     "rich",
-    "trio==0.24.0",
+    "trio",
     "trio-websocket",
 ]
 


### PR DESCRIPTION
trio was pinned to 0.24.0 due to some instabilities in 0.25.0 version in CI
runs. Right now the newest version is 0.28.0, so it might already be fixed.
Additionally new trio version is required to run with Python 3.13, which is the
latest stable release.