### PR TITLE
dependencies: pin trio-websocket to 0.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyyaml",
     "rich",
     "trio",
-    "trio-websocket",
+    "trio-websocket==0.11.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
trio-websocket v0.12 introduced a bug that causes the library to use port 80 for wss urls instead of port 443. Details are in the PR: https://github.com/python-trio/trio-websocket/pull/197

Pin the trio-websocket dependency to v0.11.1 until the fix is merged and released.