### PR TITLE
Bump version to v0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golioth"
-version = "0.6.3"
+version = "0.7.0"
 authors = [
     { name="Marcin Niestroj", email="m.niestroj@emb.dev" },
     { name="Sam Friedman", email="sam@golioth.io" }


### PR DESCRIPTION
This should have bumped to v0.7.0 with the addition of the new packages and cohorts functionality in v0.6.5. Bumping now to get fixes to dependencies.