### PR TITLE
logs: bump the timeout value from 5s to 10s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.1] - 2025-11-06
+
+### Changed
+
+- Device logs get timeout moved from 5s to 10s to give server more time to respond to requests
+
 ## [v0.8.0] - 2025-10-24
 
 ### Removed

--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -219,7 +219,7 @@ class Project(ApiNodeMixin):
         await self.delete_device(dev)
 
     async def get_logs(self, params: dict = {}) -> list[LogEntry]:
-        resp = await self.get('logs', params=params)
+        resp = await self.get('logs', params=params, timeout=10)
         return [LogEntry(e) for e in reversed(resp.json()['list'])]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golioth"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     { name="Marcin Niestroj", email="m.niestroj@emb.dev" },
     { name="Sam Friedman", email="sam@golioth.io" },


### PR DESCRIPTION
we have observed logs get failing on our CI because of the 5s timeout, and other test passing that took just under 5s to return. Bump the timeout value to 10s to give the server more time to respond to the logs get request.