### PR TITLE
artifacts: omit blueprint when value is None

### DIFF
--- a/golioth/golioth.py
+++ b/golioth/golioth.py
@@ -780,8 +780,10 @@ class ProjectArtifacts(ApiNodeMixin):
             'content': b64encode(path.open('rb').read()).decode(),
             'version': version,
             'package': package,
-            'blueprintId': blueprint_id
         }
+
+        if blueprint_id is not None:
+            json['blueprintId'] = blueprint_id
 
         try:
             response = await self.project.client.post('artifacts', json=json)


### PR DESCRIPTION
When a blueprintId is not supplied, the key should be omitted from the json passed as the request body.